### PR TITLE
Fix mobile sidebar overlay

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -111,7 +111,7 @@ h1 {
     height: 100vh;
     transition: left .3s ease;
     box-shadow: 2px 0 8px rgba(0, 0, 0, .15);
-    z-index: 1040;
+    z-index: 1060; /* ensure sidebar overlays other elements */
     background-color: #000 !important;
     color: #fff;
   }


### PR DESCRIPTION
## Summary
- ensure the sidebar overlays the mobile logo by setting a higher `z-index` for `#mainNav`

## Testing
- `n/a` (no tests included)

------
https://chatgpt.com/codex/tasks/task_e_68584f1a872c8320bdd0ef361faf8c85