### PR TITLE
Adjust hero section and add service highlights

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -330,7 +330,7 @@ h1 {
 /* ---------------------------------- */
 .main-hero {
   position: relative;
-  height: 100vh;
+  height: 75vh;
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -352,6 +352,39 @@ h1 {
 .main-hero .container {
   position: relative;
   z-index: 1;
+}
+
+/* Highlights below hero */
+.hero-highlights {
+  display: flex;
+  min-height: 25vh;
+}
+
+.hero-highlights .highlight-col {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1rem;
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+.hero-highlights .highlight-col.black {
+  background: #000;
+  color: #d2fc08;
+}
+
+.hero-highlights .highlight-col.lime {
+  background: #d2fc08;
+  color: #000;
+}
+
+@media (max-width: 768px) {
+  .hero-highlights {
+    flex-direction: column;
+  }
 }
 
 .features h3 {

--- a/index.html
+++ b/index.html
@@ -66,6 +66,12 @@
     </div>
   </header>
 
+  <section class="hero-highlights">
+    <div class="highlight-col black">Nutrición</div>
+    <div class="highlight-col lime">Planes de entrenamiento</div>
+    <div class="highlight-col black">Seguimiento</div>
+  </section>
+
   <!-- ------------------------------------------------ -->
   <!-- FEATURES                                         -->
   <!-- ------------------------------------------------ -->


### PR DESCRIPTION
## Summary
- reduce hero height so it only covers 3/4 of the viewport
- introduce a new section right after the hero highlighting nutrition, plans and progress
- style the highlights in alternating black and lime colors and make them responsive

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858508e8f088320b64ddda0c6053ed4